### PR TITLE
Change array label heuristic

### DIFF
--- a/mc_rtc_rviz_panel/src/ArrayLabelWidget.cpp
+++ b/mc_rtc_rviz_panel/src/ArrayLabelWidget.cpp
@@ -23,7 +23,7 @@ ArrayLabelWidget::ArrayLabelWidget(const ClientWidgetParam & param, const std::v
 
 void ArrayLabelWidget::update(const Eigen::VectorXd & data)
 {
-  if(normLabel_)
+  if(normLabel_ && data.size() > 6)
   {
     std::stringstream ss;
     ss << "<font>";
@@ -41,6 +41,10 @@ void ArrayLabelWidget::update(const Eigen::VectorXd & data)
   }
   else
   {
+    if(normLabel_)
+    {
+      normLabel_->hide();
+    }
     ArrayInputWidget::update(data);
   }
 }

--- a/mc_rtc_rviz_panel/src/ArrayLabelWidget.cpp
+++ b/mc_rtc_rviz_panel/src/ArrayLabelWidget.cpp
@@ -23,7 +23,7 @@ ArrayLabelWidget::ArrayLabelWidget(const ClientWidgetParam & param, const std::v
 
 void ArrayLabelWidget::update(const Eigen::VectorXd & data)
 {
-  if(normLabel_ && data.size() > 6)
+  if(normLabel_)
   {
     std::stringstream ss;
     ss << "<font>";
@@ -37,14 +37,14 @@ void ArrayLabelWidget::update(const Eigen::VectorXd & data)
     }
     ss << "</font>";
     normLabel_->setToolTip(ss.str().c_str());
-    normLabel_->setText(QString::number(data.norm()));
+    normLabel_->setText("norm = " + QString::number(data.norm()));
+    if(data.size() <= 6)
+    {
+      ArrayInputWidget::update(data);
+    }
   }
   else
   {
-    if(normLabel_)
-    {
-      normLabel_->hide();
-    }
     ArrayInputWidget::update(data);
   }
 }

--- a/mc_rtc_rviz_panel/src/utils.cpp
+++ b/mc_rtc_rviz_panel/src/utils.cpp
@@ -98,18 +98,6 @@ std::vector<vm::Marker> makeArrowMarker(const Eigen::Vector3d & start,
   m.color.g = c.color.g;
   m.color.b = c.color.b;
   markers.push_back(m);
-
-  if(c.start_point_scale > 0)
-  {
-    markers.push_back(getPointMarker(start, c.color, c.start_point_scale));
-    markers.back().action = m.action;
-  }
-
-  if(c.end_point_scale > 0)
-  {
-    markers.push_back(getPointMarker(end, c.color, c.end_point_scale));
-    markers.back().action = m.action;
-  }
   return markers;
 }
 

--- a/mc_rtc_rviz_panel/src/utils.h
+++ b/mc_rtc_rviz_panel/src/utils.h
@@ -77,10 +77,6 @@ struct SharedMarker
 
   void applyChanges()
   {
-    // XXX without erasing and re-inserting the marker, applyChanges does
-    // nothing when the marker controls have been modified.
-    server_->erase(marker_.name);
-    server_->insert(marker_, callback_);
     server_->applyChanges();
   }
 


### PR DESCRIPTION
This PR changes the `ArrayLabel` heuristic so that small vectors (size <= 6) are fully displayed while for larger vectors only the norm is displayed

Fixes jrl-umi3218/mc_rtc#29

Note: this also pulls in an old patch from the GitLab