### PR TITLE
Live plotting improvements

### DIFF
--- a/mc_rtc_rviz_panel/src/PlotWidget.cpp
+++ b/mc_rtc_rviz_panel/src/PlotWidget.cpp
@@ -96,7 +96,11 @@ PlotWidget::Curve & PlotWidget::Curve::operator=(Curve && rhs)
   return *this;
 }
 
-QRectF PlotWidget::Curve::update(double x, double y, mc_rtc::gui::Color color, mc_rtc::gui::plot::Style style, double line_width)
+QRectF PlotWidget::Curve::update(double x,
+                                 double y,
+                                 mc_rtc::gui::Color color,
+                                 mc_rtc::gui::plot::Style style,
+                                 double line_width)
 {
   if(samples_.size() == 0)
   {
@@ -308,7 +312,7 @@ PlotWidget::PlotWidget(const std::string & title, QWidget * parent) : QWidget(pa
   connect(options_button_, SIGNAL(clicked()), this, SLOT(toggle_options_widget()));
   hlayout->addWidget(options_button_);
   layout->addLayout(hlayout);
-  
+
   // Additional options group (line width, etc), hidden by default
   options_widget_ = new QGroupBox("Style Options", this);
   options_widget_->setVisible(false);

--- a/mc_rtc_rviz_panel/src/PlotWidget.h
+++ b/mc_rtc_rviz_panel/src/PlotWidget.h
@@ -133,7 +133,7 @@ private:
   double show_duration_ = 10;
   QPushButton * pause_button_;
   bool paused_ = false;
-  
+
   QPushButton * options_button_;
   QGroupBox * options_widget_;
   double line_width_ = 1.;

--- a/mc_rtc_rviz_panel/src/PlotWidget.h
+++ b/mc_rtc_rviz_panel/src/PlotWidget.h
@@ -130,9 +130,14 @@ private:
   mc_rtc::gui::plot::Range yLeftRange_;
   mc_rtc::gui::plot::Range yRightRange_;
   bool limit_xrange_ = false;
+  double show_duration_ = 10;
+  QPushButton * pause_button_;
+  bool paused_ = false;
 private slots:
   void limit_xrange_cbox_changed(int);
-  void save_button_released();
+  void show_duration_changed(double);
+  void save_button_clicked();
+  void pause_button_clicked();
 };
 
 } // namespace mc_rtc_rviz

--- a/mc_rtc_rviz_panel/src/PlotWidget.h
+++ b/mc_rtc_rviz_panel/src/PlotWidget.h
@@ -67,7 +67,7 @@ private:
     Curve(Curve && rhs);
     Curve & operator=(Curve && rhs);
     ~Curve();
-    QRectF update(double x, double y, mc_rtc::gui::Color color, mc_rtc::gui::plot::Style style);
+    QRectF update(double x, double y, mc_rtc::gui::Color color, mc_rtc::gui::plot::Style style, double line_width);
 
   private:
     QwtPlotCurve * curve_ = nullptr;
@@ -133,11 +133,17 @@ private:
   double show_duration_ = 10;
   QPushButton * pause_button_;
   bool paused_ = false;
+  
+  QPushButton * options_button_;
+  QGroupBox * options_widget_;
+  double line_width_ = 1.;
 private slots:
   void limit_xrange_cbox_changed(int);
   void show_duration_changed(double);
   void save_button_clicked();
   void pause_button_clicked();
+  void toggle_options_widget();
+  void line_width_changed(double);
 };
 
 } // namespace mc_rtc_rviz


### PR DESCRIPTION
This PR improves the live plot widget:
- Adds the ability to pause/resume
- Lets the user choose the display time duration
- Additional options to select line size (hidden by default to not clutter the gui)

![plot](https://user-images.githubusercontent.com/67139/98889158-bbf91380-24dc-11eb-8318-fcf78ffbf6fb.png)
