### PR TITLE
[panel] Recursively resolve allOf property

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
       run: |
         export PATH=/usr/local/opt/qt/bin:$PATH
         echo "PATH=${PATH}" >> $GITHUB_ENV
-        export CMAKE_PREFIX_PATH=/usr/local/opt/qt:${CMAKE_PREFIX_PATH}
+        export CMAKE_PREFIX_PATH=/usr/local/opt/qt@5:${CMAKE_PREFIX_PATH}
         echo "CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}" >> $GITHUB_ENV
     - name: Install dependencies
       uses: jrl-umi3218/github-actions/install-dependencies@master
@@ -94,7 +94,7 @@ jobs:
         ubuntu: |
           apt: cython cython3 python-nose python3-nose python-numpy python3-numpy python-coverage python3-coverage python-setuptools python3-setuptools libeigen3-dev doxygen doxygen-latex libboost-all-dev libtinyxml2-dev libgeos++-dev libnanomsg-dev libyaml-cpp-dev libltdl-dev qt5-default libqwt-qt5-dev
         macos: |
-          brew: eigen boost tinyxml2 geos nanomsg yaml-cpp pkg-config libtool qt qwt gcc
+          brew: eigen boost tinyxml2 geos nanomsg yaml-cpp pkg-config libtool qt5 qwt gcc
           pip: Cython coverage nose numpy
           github:
             - path: jrl-umi3218/mc_rtc_data

--- a/mc_rtc_rviz_panel/src/Schema.h
+++ b/mc_rtc_rviz_panel/src/Schema.h
@@ -63,6 +63,10 @@ struct Schema
   static SchemaStore & store();
 
 private:
+  /** Recursively resolve allOf property */
+  mc_rtc::Configuration resolveAllOf(const mc_rtc::Configuration & s, const std::string & source) const;
+
+private:
   std::string title_;
   bool is_object_ = false;
   bool is_tuple_ = false;


### PR DESCRIPTION
This PR adds support for recursive `allOf` properties in JSON schemas, e.g

```json
    "allOf":
    [
      {
        "type": "object"
      }
      {
        "allOf":
        [
          {
            "properties":
            {
               "type": "number"
            }
          },
          {
            "$ref": "/../../ref.json"
          }
        ]
      }
    ]
```

This is necessary to support the reorganized StabilizerTask schemas of https://github.com/jrl-umi3218/mc_rtc/pull/95