### PR TITLE
[panel/visual] Fix display of scaleV

### DIFF
--- a/mc_rtc_rviz_panel/src/VisualWidget.cpp
+++ b/mc_rtc_rviz_panel/src/VisualWidget.cpp
@@ -100,9 +100,9 @@ void VisualWidget::update(const rbd::parsers::Visual & visual, const sva::PTrans
     {
       auto & m = boost::get<Geometry::Mesh>(geom_data);
       marker_.type = visualization_msgs::Marker::MESH_RESOURCE;
-      marker_.scale.x = m.scale;
-      marker_.scale.y = m.scale;
-      marker_.scale.z = m.scale;
+      marker_.scale.x = m.scaleV.x();
+      marker_.scale.y = m.scaleV.y();
+      marker_.scale.z = m.scaleV.z();
       marker_.mesh_resource = m.filename;
       marker_.mesh_use_embedded_materials = true;
     }


### PR DESCRIPTION
This PR properly handles the `scaleV` property of a visual mesh.

See https://github.com/jrl-umi3218/mc_rtc/pull/430