### PR TITLE
fix(markers): Ensure Arrowmarkerwidget is deleted

### DIFF
--- a/mc_rtc_rviz_panel/src/ArrowInteractiveMarkerWidget.cpp
+++ b/mc_rtc_rviz_panel/src/ArrowInteractiveMarkerWidget.cpp
@@ -54,6 +54,12 @@ ArrowInteractiveMarkerWidget::ArrowInteractiveMarkerWidget(const ClientWidgetPar
   connect(button_, SIGNAL(toggled(bool)), this, SLOT(toggled(bool)));
 }
 
+ArrowInteractiveMarkerWidget::~ArrowInteractiveMarkerWidget()
+{
+  arrow_marker_.action = Marker::DELETE;
+  markers_.markers.push_back(arrow_marker_);
+}
+
 void ArrowInteractiveMarkerWidget::update(const Eigen::Vector3d & start,
                                           const Eigen::Vector3d & end,
                                           const mc_rtc::gui::ArrowConfig & c)

--- a/mc_rtc_rviz_panel/src/ArrowInteractiveMarkerWidget.h
+++ b/mc_rtc_rviz_panel/src/ArrowInteractiveMarkerWidget.h
@@ -21,6 +21,7 @@ public:
                                bool control_start,
                                bool control_end,
                                ClientWidget * label);
+  ~ArrowInteractiveMarkerWidget();
 
   void update(const Eigen::Vector3d & start, const Eigen::Vector3d & end, const mc_rtc::gui::ArrowConfig & c);
 


### PR DESCRIPTION
Some markers are not correctly deleted after the GUI element is removed from mc_rtc GUI server: they remain in rviz forever. This is because we need to explicitly delete non-interactive markers as done here.

I fixed this issue for Arrow markers (and forces) now, but there might be other elements that behave the same way. Feel free to mention them if you notice it, or better yet open a similar PR :)

@ThomasDuvinage