### PR TITLE
Handle updated schemas

### DIFF
--- a/mc_rtc_rviz_panel/src/FormElement.cpp
+++ b/mc_rtc_rviz_panel/src/FormElement.cpp
@@ -477,20 +477,21 @@ DataComboInput::DataComboInput(QWidget * parent,
   combo_ = new QComboBox(this);
   combo_->installEventFilter(this);
   combo_->setFocusPolicy(Qt::StrongFocus);
+  connect(combo_, SIGNAL(currentIndexChanged(int)), this, SLOT(currentIndexChanged(int)));
   layout->addWidget(combo_);
   reset();
 }
 
 void DataComboInput::reset()
 {
-  combo_->disconnect();
+  combo_->blockSignals(true);
   combo_->clear();
   values_.clear();
   resolved_ref_ = ref_;
   if(resolve_ref()) { update_values(); }
   combo_->setCurrentIndex(-1);
   ready_ = false;
-  connect(combo_, SIGNAL(currentIndexChanged(int)), this, SLOT(currentIndexChanged(int)));
+  combo_->blockSignals(false);
 }
 
 void DataComboInput::changed(bool required,

--- a/mc_rtc_rviz_panel/src/FormElement.cpp
+++ b/mc_rtc_rviz_panel/src/FormElement.cpp
@@ -652,12 +652,25 @@ Form::Form(QWidget * parent,
 
 bool Form::ready() const
 {
-  bool ok = true;
-  for(const auto & el : elements_)
-  {
-    if(el->required() && !el->ready()) { return false; }
+  if(required())
+  { // for required forms, return true if all required elements have been completed
+    for(const auto & el : elements_)
+    {
+      if(el->required() && !el->ready()) { return false; }
+    }
+    return true;
   }
-  return ok;
+  else
+  { // optional, if at least one element was filled return true
+    for(const auto & el : elements_)
+    {
+      if(el->ready())
+      { // optional element was modified
+        return true;
+      }
+    }
+    return false;
+  }
 }
 
 mc_rtc::Configuration Form::serialize() const

--- a/mc_rtc_rviz_panel/src/FormElement.h
+++ b/mc_rtc_rviz_panel/src/FormElement.h
@@ -45,6 +45,8 @@ public:
 
   virtual inline void unlock() { locked_ = false; }
 
+  void required(bool required) { required_ = required; }
+
   bool required() const { return required_; }
 
   bool show_name() const { return show_name_; }

--- a/mc_rtc_rviz_panel/src/Schema.cpp
+++ b/mc_rtc_rviz_panel/src/Schema.cpp
@@ -17,9 +17,8 @@ namespace
 
 std::string ref_path(const std::string & source, const std::string & ref_)
 {
-  auto ref = ref_.substr(3); // remove leading /..
   bfs::path ref_schema{source};
-  ref_schema = bfs::canonical(ref_schema.parent_path() / ref);
+  ref_schema = bfs::canonical(ref_schema.parent_path() / ref_);
   return ref_schema.string();
 }
 

--- a/mc_rtc_rviz_panel/src/Schema.cpp
+++ b/mc_rtc_rviz_panel/src/Schema.cpp
@@ -315,7 +315,7 @@ void Schema::init(const mc_rtc::Configuration & s,
       mc_rtc::log::warning("{}{} in {} is an array but items' type is not specified", desc, k, source);
     }
   };
-  auto handle_object = [&](const std::string & titleIn, const mc_rtc::Configuration & schemaIn)
+  auto handle_object = [&](const std::string & titleIn, const mc_rtc::Configuration & schemaIn, bool requiredInParent)
   {
     if(!schemaIn.has("properties"))
     {
@@ -345,12 +345,13 @@ void Schema::init(const mc_rtc::Configuration & s,
         const auto & schema = resolve_ref(source, prop("$ref"), k);
         auto cf = create_form;
         bool requiredIn = is_required(k);
-        create_form = [cf, k, requiredIn, &schema](QWidget * parent, const mc_rtc::Configuration & data)
+        create_form =
+            [cf, k, requiredIn, requiredInParent, &schema](QWidget * parent, const mc_rtc::Configuration & data)
         {
           auto v = cf(parent, data);
           if(schema.is_object())
           {
-            v.emplace_back(new form::Form(parent, k, requiredIn, schema.create_form(parent, data)));
+            v.emplace_back(new form::Form(parent, k, requiredInParent, schema.create_form(parent, data)));
           }
           else
           {
@@ -377,7 +378,7 @@ void Schema::init(const mc_rtc::Configuration & s,
   if(type == "object")
   {
     is_object_ = true;
-    handle_object(title_, s);
+    handle_object(title_, s, required_in);
   }
   else if(type == "array") { handle_array("", title_, required_in, s); }
   else

--- a/mc_rtc_rviz_panel/src/Schema.cpp
+++ b/mc_rtc_rviz_panel/src/Schema.cpp
@@ -103,6 +103,18 @@ void Schema::init(const mc_rtc::Configuration & s,
       return v;
     };
   };
+  /** Handle const entries */
+  auto handle_const = [this](const std::string & k, bool requiredIn, const std::string & value)
+  {
+    auto cf = create_form;
+    create_form = [cf, k, requiredIn, value](QWidget * parent, const mc_rtc::Configuration & data)
+    {
+      auto v = cf(parent, data);
+      v.emplace_back(new form::StringInput(parent, k, requiredIn, value, true));
+      if(value.size() && requiredIn) { v.back()->hidden(true); }
+      return v;
+    };
+  };
   /** Handle: boolean/integer/number/string */
   auto handle_type = [this, &source](const std::string & k, bool requiredIn, const std::string & type,
                                      const mc_rtc::Configuration & schema)
@@ -315,6 +327,10 @@ void Schema::init(const mc_rtc::Configuration & s,
     {
       auto prop = properties(k);
       if(prop.has("enum")) { handle_enum(k, is_required(k), prop("enum")); }
+      else if(prop.has("const"))
+      {
+        handle_const(k, is_required(k), prop("const"));
+      }
       else if(prop.has("type"))
       {
         std::string type = prop("type");

--- a/mc_rtc_rviz_panel/src/Schema.cpp
+++ b/mc_rtc_rviz_panel/src/Schema.cpp
@@ -335,7 +335,7 @@ void Schema::init(const mc_rtc::Configuration & s,
       mc_rtc::log::warning("{}{} in {} is an array but items' type is not specified", desc, k, source);
     }
   };
-  auto handle_object = [&](const std::string & titleIn, const mc_rtc::Configuration & schemaIn, bool requiredInParent)
+  auto handle_object = [&](const std::string & titleIn, const mc_rtc::Configuration & schemaIn)
   {
     if(!schemaIn.has("properties"))
     {
@@ -362,13 +362,12 @@ void Schema::init(const mc_rtc::Configuration & s,
         const auto & schema = resolve_ref(source, prop("$ref"), k);
         auto cf = create_form;
         bool requiredIn = is_required(k);
-        create_form =
-            [cf, k, requiredIn, requiredInParent, &schema](QWidget * parent, const mc_rtc::Configuration & data)
+        create_form = [cf, k, requiredIn, &schema](QWidget * parent, const mc_rtc::Configuration & data)
         {
           auto v = cf(parent, data);
           if(schema.is_object())
           {
-            v.emplace_back(new form::Form(parent, k, requiredInParent, schema.create_form(parent, data)));
+            v.emplace_back(new form::Form(parent, k, requiredIn, schema.create_form(parent, data)));
           }
           else
           {
@@ -396,7 +395,7 @@ void Schema::init(const mc_rtc::Configuration & s,
   if(type == "object")
   {
     is_object_ = true;
-    handle_object(title_, s, required_in);
+    handle_object(title_, s);
   }
   else if(type == "array") { handle_array("", title_, required_in, s); }
   else

--- a/mc_rtc_rviz_panel/src/Schema.cpp
+++ b/mc_rtc_rviz_panel/src/Schema.cpp
@@ -327,10 +327,7 @@ void Schema::init(const mc_rtc::Configuration & s,
     {
       auto prop = properties(k);
       if(prop.has("enum")) { handle_enum(k, is_required(k), prop("enum")); }
-      else if(prop.has("const"))
-      {
-        handle_const(k, is_required(k), prop("const"));
-      }
+      else if(prop.has("const")) { handle_const(k, is_required(k), prop("const")); }
       else if(prop.has("type"))
       {
         std::string type = prop("type");

--- a/mc_rtc_rviz_panel/src/Schema.cpp
+++ b/mc_rtc_rviz_panel/src/Schema.cpp
@@ -353,6 +353,7 @@ void Schema::init(const mc_rtc::Configuration & s,
           else
           {
             auto el = schema.create_form(parent, data).at(0);
+            el->required(requiredIn);
             el->name(k);
             v.push_back(el);
           }

--- a/mc_rtc_rviz_panel/src/SchemaArrayInput.cpp
+++ b/mc_rtc_rviz_panel/src/SchemaArrayInput.cpp
@@ -56,6 +56,7 @@ void SchemaArrayInput::reset()
   }
   items_.clear();
   for(int i = 0; i < min_size_; ++i) { addItem(); }
+  ready_ = false;
 }
 
 mc_rtc::Configuration SchemaArrayInput::serialize() const


### PR DESCRIPTION
This PR adapts the Schema GUI builder to support the last changes in https://github.com/jrl-umi3218/mc_rtc/pull/483, namely:
- Handle `const` properties in addition to `enum`. This is needed so that LSP can match `oneOf` schema choices to an actual schema.
- Do not serialize non-required empty objects. This was actually a bug preventing some type of tasks to be loaded with default properties from the panel. If no input is made in nested objects, then they should not be serialized, otherwise the loading code on mc_rtc side will attempt to load the nested-object's required properties.
- Fix handling of nested object required properties. This one is a bit tricky, essentially we create all elements in a schema and all sub-schemas as nested Form elements in the  GUI. Properties required in the main schema are always required to be filled-in (by default or the user). In sub-schemas it's a bit more complex, as required properties are only required if the schema itself is required, otherwise they are not (unless an element of the schema is filled, in which case they are again required)
```json
{
  "type": "object",
  "properties": {
    "property1": { "type": "number" },
    "ChildObject": {
      "type": "object",
      "properties": {
        "childproperty1": { "type": "number" }
      },
      "required": ["childproperty1"]
    }
  },
  "required": ["ChildObject"]
}
```
Here `childproperty1` is only required if ChildObject is required.

Must be merged along with https://github.com/jrl-umi3218/mc_rtc/pull/483